### PR TITLE
Refactor Tests to Enable Parallel UI Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5910,6 +5910,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.5.0",
       "license": "MIT",

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -13,13 +13,13 @@ const { defineConfig, devices } = require("@playwright/test");
 module.exports = defineConfig({
   testDir: "./tests",
   /* Run tests in files in parallel */
-  fullyParallel: false,
+  fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: 1,
+  workers: 4,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -38,15 +38,15 @@ module.exports = defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/tests/categoryProduct.spec.cjs
+++ b/tests/categoryProduct.spec.cjs
@@ -1,55 +1,40 @@
 // @ts-check
 const { test, expect } = require("@playwright/test");
-const fetch = require("node-fetch");
+const {
+  loginAsAdmin,
+  createProduct,
+  deleteProduct,
+} = require("../utilities/testUtils");
 
 test.describe.configure({ mode: "serial" });
 
 test.describe("Category Product Page", () => {
-  const adminEmail = "admin@test.sg";
-  const adminPassword = "admin@test.sg";
   const productName = `PlaywrightCategoryProduct-${Date.now()}`;
   const categorySlug = "electronics";
+  let createdProduct = null;
+  let adminToken = null;
 
-  test.beforeAll(async ({ browser }) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
+  test.beforeAll(async () => {
+    adminToken = await loginAsAdmin();
+    createdProduct = await createProduct({
+      name: productName,
+      description: "Category page test",
+      price: 99,
+      quantity: 4,
+      shipping: 1,
+      token: adminToken,
+    });
 
-    // Login as admin
-    await page.goto("http://localhost:3000/login");
-    await page.getByPlaceholder("Enter Your Email").fill(adminEmail);
-    await page.getByPlaceholder("Enter Your Password").fill(adminPassword);
-    await page.getByRole("button", { name: "LOGIN" }).click();
-    await page.waitForURL("http://localhost:3000/");
-
-    // Create product
-    await page.goto("http://localhost:3000/dashboard/admin/create-product");
-
-    await page.locator(".ant-select-selector").first().click();
-    await page
-      .locator(".ant-select-item-option", { hasText: "Electronics" })
-      .click();
-
-    await page.getByPlaceholder("write a name").fill(productName);
-    await page
-      .getByPlaceholder("write a description")
-      .fill("Category page test");
-    await page.getByPlaceholder("write a Price").fill("99");
-    await page.getByPlaceholder("write a quantity").fill("4");
-
-    await page.locator(".ant-select-selector").nth(1).click();
-    await page.locator(".ant-select-item-option", { hasText: "Yes" }).click();
-
-    await page.getByRole("button", { name: "CREATE PRODUCT" }).click();
-    await page.waitForTimeout(1000);
-
-    await context.close();
+    if (!createdProduct?.id) {
+      throw new Error("Product creation failed");
+    }
   });
 
   test("should display products under category", async ({ page }) => {
     await page.goto(`http://localhost:3000/category/${categorySlug}`);
 
     await expect(page.getByText(`Category - Electronics`)).toBeVisible();
-    await expect(page.getByText(productName)).toBeVisible();
+    await expect(page.getByText(productName).first()).toBeVisible();
     await expect(
       page.getByRole("button", { name: "More Details" }).first()
     ).toBeVisible();
@@ -60,7 +45,11 @@ test.describe("Category Product Page", () => {
   }) => {
     await page.goto(`http://localhost:3000/category/${categorySlug}`);
 
-    await page.getByRole("button", { name: "More Details" }).first().click();
+    const productCard = page.locator(".card", { hasText: productName });
+    await expect(productCard).toBeVisible();
+
+    await productCard.getByRole("button", { name: "More Details" }).click();
+
     await expect(page).toHaveURL(/\/product\//);
     await expect(page.getByText(productName)).toBeVisible();
   });
@@ -75,27 +64,8 @@ test.describe("Category Product Page", () => {
   });
 
   test.afterAll(async () => {
-    try {
-      const response = await fetch(
-        "http://localhost:3000/api/v1/product/get-product"
-      );
-      const data = await response.json();
-      const match = data.products.find((p) => p.name === productName);
-
-      if (match) {
-        const deleteResponse = await fetch(
-          `http://localhost:3000/api/v1/product/delete-product/${match._id}`,
-          { method: "DELETE" }
-        );
-
-        if (!deleteResponse.ok) {
-          throw new Error(
-            `Failed to delete product. Status: ${deleteResponse.status}`
-          );
-        }
-      }
-    } catch (e) {
-      console.error("Cleanup failed:", e.message);
+    if (createdProduct?.id) {
+      await deleteProduct(createdProduct.id);
     }
   });
 });

--- a/tests/products.spec.cjs
+++ b/tests/products.spec.cjs
@@ -1,65 +1,37 @@
 // @ts-check
 const { test, expect } = require("@playwright/test");
-const fetch = require("node-fetch");
+const {
+  loginAsAdmin,
+  createProduct,
+  deleteProduct,
+} = require("../utilities/testUtils");
 
 test.describe.configure({ mode: "serial" });
 
 test.describe("Product Details Page", () => {
-  const adminEmail = "admin@test.sg";
-  const adminPassword = "admin@test.sg";
   const productName = `PlaywrightDetailProduct-${Date.now()}`;
-  let productSlug = null;
-  let createdProductId = null;
+  let createdProduct = null;
+  let adminToken = null;
 
-  test.beforeAll(async ({ browser }) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
+  test.beforeAll(async () => {
+    adminToken = await loginAsAdmin();
 
-    // Login as admin
-    await page.goto("http://localhost:3000/login");
-    await page
-      .getByRole("textbox", { name: "Enter Your Email" })
-      .fill(adminEmail);
-    await page
-      .getByRole("textbox", { name: "Enter Your Password" })
-      .fill(adminPassword);
-    await page.getByRole("button", { name: "LOGIN" }).click();
-    await page.waitForURL("http://localhost:3000/");
+    createdProduct = await createProduct({
+      name: productName,
+      description: "Playwright detail product",
+      price: 123,
+      quantity: 5,
+      shipping: 1,
+      token: adminToken,
+    });
 
-    // Create product
-    await page.goto("http://localhost:3000/dashboard/admin/create-product");
-
-    await page.locator(".ant-select-selector").first().click();
-    await page.locator(".ant-select-item-option").first().click();
-
-    await page.getByPlaceholder("write a name").fill(productName);
-    await page
-      .getByPlaceholder("write a description")
-      .fill("Playwright detail product");
-    await page.getByPlaceholder("write a Price").fill("123");
-    await page.getByPlaceholder("write a quantity").fill("5");
-
-    await page.locator(".ant-select-selector").nth(1).click();
-    await page.locator(".ant-select-item-option", { hasText: "Yes" }).click();
-
-    await page.getByRole("button", { name: "CREATE PRODUCT" }).click();
-    await page.waitForTimeout(1000);
-    await context.close();
-
-    // Get product slug and id
-    const response = await fetch(
-      "http://localhost:3000/api/v1/product/get-product"
-    );
-    const data = await response.json();
-    const product = data.products.find((p) => p.name === productName);
-    if (product) {
-      productSlug = product.slug;
-      createdProductId = product._id;
+    if (!createdProduct?.id || !createdProduct?.slug) {
+      throw new Error("Product creation failed or slug missing");
     }
   });
 
   test("should display product details correctly", async ({ page }) => {
-    await page.goto(`http://localhost:3000/product/${productSlug}`);
+    await page.goto(`http://localhost:3000/product/${createdProduct.slug}`);
 
     await expect(page.getByText("Product Details")).toBeVisible();
     await expect(
@@ -75,33 +47,8 @@ test.describe("Product Details Page", () => {
   });
 
   test.afterAll(async () => {
-    try {
-      const response = await fetch(
-        "http://localhost:3000/api/v1/product/get-product"
-      );
-      const data = await response.json();
-      const match = data.products.find((p) => p.name === productName);
-
-      if (match) {
-        const deleteResponse = await fetch(
-          `http://localhost:3000/api/v1/product/delete-product/${match._id}`,
-          {
-            method: "DELETE",
-          }
-        );
-
-        const result = await deleteResponse.json();
-
-        if (!deleteResponse.ok) {
-          throw new Error(
-            `Failed to delete product. Status: ${deleteResponse.status}`
-          );
-        }
-      } else {
-        console.warn("Product not found for cleanup.");
-      }
-    } catch (e) {
-      console.error("Cleanup failed:", e.message);
+    if (createdProduct?.id) {
+      await deleteProduct(createdProduct.id);
     }
   });
 });

--- a/tests/search.spec.cjs
+++ b/tests/search.spec.cjs
@@ -1,59 +1,33 @@
 // @ts-check
 const { test, expect } = require("@playwright/test");
-const fetch = require("node-fetch");
+const {
+  loginAsAdmin,
+  createProduct,
+  deleteProduct,
+} = require("../utilities/testUtils");
 
 test.describe.configure({ mode: "serial" });
 
 test.describe("Search Page", () => {
-  const adminEmail = "admin@test.sg";
-  const adminPassword = "admin@test.sg";
   const productName = `PlaywrightSearchProduct-${Date.now()}`;
+  let createdProduct;
+  let adminToken;
 
-  test.beforeAll(async ({ browser }) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-
-    // Login as admin
-    await page.goto("http://localhost:3000/login");
-    await page
-      .getByRole("textbox", { name: "Enter Your Email" })
-      .fill(adminEmail);
-    await page
-      .getByRole("textbox", { name: "Enter Your Password" })
-      .fill(adminPassword);
-    await page.getByRole("button", { name: "LOGIN" }).click();
-    await page.waitForURL("http://localhost:3000/");
-
-    // Create product
-    await page.goto("http://localhost:3000/dashboard/admin/create-product");
-
-    await page.locator(".ant-select-selector").first().click();
-    await page.locator(".ant-select-item-option").first().click();
-
-    await page.getByPlaceholder("write a name").fill(productName);
-    await page
-      .getByPlaceholder("write a description")
-      .fill("Search test product");
-    await page.getByPlaceholder("write a Price").fill("88");
-    await page.getByPlaceholder("write a quantity").fill("8");
-
-    await page.locator(".ant-select-selector").nth(1).click();
-    await page.locator(".ant-select-item-option", { hasText: "Yes" }).click();
-
-    await page.getByRole("button", { name: "CREATE PRODUCT" }).click();
-    await page.waitForTimeout(1000);
-
-    await context.close();
+  test.beforeAll(async () => {
+    adminToken = await loginAsAdmin();
+    createdProduct = await createProduct({
+      name: productName,
+      token: adminToken,
+    });
+    if (!createdProduct?.id) throw new Error("Product creation failed");
   });
 
   test("should show results when searching for created product", async ({
     page,
   }) => {
     await page.goto("http://localhost:3000");
-
     await page.getByPlaceholder("Search").fill(productName);
     await page.getByRole("button", { name: "Search" }).click();
-
     await page.waitForURL("**/search");
     await expect(page.getByText("Search Results")).toBeVisible();
     await expect(page.getByText(/Found 1/)).toBeVisible();
@@ -64,43 +38,16 @@ test.describe("Search Page", () => {
     page,
   }) => {
     await page.goto("http://localhost:3000");
-
     await page.getByPlaceholder("Search").fill("nonexistent-product-keyword");
     await page.getByRole("button", { name: "Search" }).click();
-
     await page.waitForURL("**/search");
     await expect(page.getByText("Search Results")).toBeVisible();
     await expect(page.getByText("No Products Found")).toBeVisible();
   });
 
   test.afterAll(async () => {
-    try {
-      const response = await fetch(
-        "http://localhost:3000/api/v1/product/get-product"
-      );
-      const data = await response.json();
-      const match = data.products.find((p) => p.name === productName);
-
-      if (match) {
-        const deleteResponse = await fetch(
-          `http://localhost:3000/api/v1/product/delete-product/${match._id}`,
-          {
-            method: "DELETE",
-          }
-        );
-
-        const result = await deleteResponse.json();
-
-        if (!deleteResponse.ok) {
-          throw new Error(
-            `Failed to delete product. Status: ${deleteResponse.status}`
-          );
-        }
-      } else {
-        console.warn("Product not found for cleanup.");
-      }
-    } catch (e) {
-      console.error("Cleanup failed:", e.message);
+    if (createdProduct?.id) {
+      await deleteProduct(createdProduct.id);
     }
   });
 });

--- a/utilities/testUtils.js
+++ b/utilities/testUtils.js
@@ -1,0 +1,96 @@
+const fetch = require("node-fetch");
+const FormData = require("form-data");
+
+const BASE_URL = "http://localhost:3000";
+
+async function loginAsAdmin() {
+  const res = await fetch(`${BASE_URL}/api/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "admin@test.sg",
+      password: "admin@test.sg",
+    }),
+  });
+
+  const data = await res.json();
+  const token = data?.token;
+  if (!token) throw new Error("Failed to get admin token");
+
+  return token;
+}
+
+async function getFirstCategoryId() {
+  const res = await fetch(`${BASE_URL}/api/v1/category/get-category`);
+  const data = await res.json();
+  return data?.category?.[0]?._id;
+}
+
+async function createProduct({
+  name,
+  description = "Test description",
+  price = 100,
+  quantity = 10,
+  shipping = 1,
+  categoryId = null,
+  token,
+}) {
+  if (!name) throw new Error("Product name is required");
+  if (!token) throw new Error("Token is required to create a product");
+
+  const resolvedCategoryId = categoryId || (await getFirstCategoryId());
+  if (!resolvedCategoryId) throw new Error("No category available");
+
+  const form = new FormData();
+  form.append("name", name);
+  form.append("description", description);
+  form.append("price", price);
+  form.append("quantity", quantity);
+  form.append("shipping", shipping);
+  form.append("category", resolvedCategoryId);
+
+  const res = await fetch(`${BASE_URL}/api/v1/product/create-product`, {
+    method: "POST",
+    body: form,
+    headers: {
+      Authorization: token,
+    },
+  });
+
+  const raw = await res.text();
+
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    throw new Error("Product creation failed: Response is not valid JSON");
+  }
+
+  if (!data?.products?._id) {
+    throw new Error("Product creation failed: No product ID in response");
+  }
+
+  return {
+    id: data.products._id,
+    slug: data.products.slug,
+  };
+}
+
+async function deleteProduct(productId) {
+  const res = await fetch(
+    `${BASE_URL}/api/v1/product/delete-product/${productId}`,
+    {
+      method: "DELETE",
+    }
+  );
+
+  if (!res.ok) {
+    console.warn(`Failed to delete product ${productId}`);
+  }
+}
+
+module.exports = {
+  loginAsAdmin,
+  createProduct,
+  deleteProduct,
+};


### PR DESCRIPTION
This PR creates shared util methods to use across tests to `loginAsAdmin`, `createProduct`, and `deleteProduct`. These functions make it so that the tests are independent and able to work without seed data.

Previously, the cartPage test was using the initial data and tests could not work in parallel since some tests relied on logic affecting products. Encapsulating these methods and integrating them with the cart page helps with reusability and maintainability.